### PR TITLE
OCR + Translate = `;ocrtranslate`

### DIFF
--- a/arabot/__init__.py
+++ b/arabot/__init__.py
@@ -2,7 +2,7 @@ from os import getenv as _getenv
 
 from dotenv import load_dotenv as _load_dotenv
 
-__version__ = "6.9.1"
+__version__ = "6.10.0"
 
 _load_dotenv()
 TESTING = bool(_getenv("testing"))

--- a/arabot/cogs/eval/client.py
+++ b/arabot/cogs/eval/client.py
@@ -17,8 +17,8 @@ from .abc import Evaluator
 class RemoteEval(Evaluator):
     API = "https://emkc.org/api/v2/piston/execute"
 
-    def __init__(self, *, session: ClientSession | None = None, stdin: str = ""):
-        self.session = session or ClientSession()
+    def __init__(self, *, session: ClientSession, stdin: str = ""):
+        self.session = session
         self.stdin = stdin
 
     async def fetch_response(self, code: str, *, stdin: str | None = None):

--- a/arabot/cogs/google/__init__.py
+++ b/arabot/cogs/google/__init__.py
@@ -1,5 +1,6 @@
+from os import getenv
+
 from arabot.core import Ara
-from arabot.core.utils import getkeys
 
 from .ocr import OpticalCharacterRecognition
 from .search import GSearch, ImageSearch
@@ -9,7 +10,9 @@ from .tts import TextToSpeech
 
 def setup(ara: Ara):
     session = ara.session
-    trans_client = TranslationClient(getkeys("g_trans_key")[0], session)
-    ara.add_cog(Translate(trans_client))
-    for cog in GSearch, ImageSearch, TextToSpeech, OpticalCharacterRecognition:
+    trans_client = TranslationClient(getenv("g_trans_key"), session)
+    trans = Translate(trans_client)
+    ara.add_cog(trans)
+    ara.add_cog(OpticalCharacterRecognition(trans))
+    for cog in GSearch, ImageSearch, TextToSpeech:
         ara.add_cog(cog(session))

--- a/arabot/cogs/google/ocr.py
+++ b/arabot/cogs/google/ocr.py
@@ -1,11 +1,12 @@
 import logging
 from base64 import b64encode
 
-from aiohttp import ClientSession
 from arabot.core import Category, Cog, Context
-from arabot.core.utils import codeblock
+from arabot.core.utils import codeblock, dsafe
 from disnake import Embed
 from disnake.ext.commands import command
+
+from .translate import Translate
 
 
 class OCRException(Exception):
@@ -17,49 +18,70 @@ class OCRException(Exception):
 
 
 class OpticalCharacterRecognition(Cog, category=Category.LOOKUP, keys={"g_ocr_key"}):
-    def __init__(self, session: ClientSession):
-        self.session = session
+    def __init__(self, trans: Translate):
+        self.trans = trans
 
     @command(aliases=["read"], brief="Read text from image")
     async def ocr(self, ctx: Context):
         await ctx.trigger_typing()
         image_url = await ctx.rsearch("image_url")
-        if not image_url:
-            await ctx.send("No image or link provided")
+        if text := await self.handle_annotation(ctx, image_url):
+            await ctx.send(
+                embed=Embed(description=codeblock(text))
+                .set_thumbnail(url=image_url)
+                .set_footer(
+                    text="Google Cloud Vision",
+                    icon_url="http://vision-explorer.reactive.ai/images/Vision-API.png",
+                )
+            )
+
+    @command(aliases=["otr", "ocrt", "octr", "ocrtrans"], brief="Read & translate text from image")
+    async def ocrtranslate(self, ctx: Context):
+        await ctx.trigger_typing()
+        image_url = await ctx.rsearch("image_url")
+        if not (text := await self.handle_annotation(ctx, image_url)):
             return
+
+        langs = await self.trans.gtrans.languages(repr_lang=self.trans.DEFAULT_TARGET[0])
+        source, target, _ = self.trans.parse_query(ctx.argument_only, langs)
+        if translation := await self.trans.handle_translation(ctx, source, target, text, langs):
+            (source, text), (target, trans_text) = translation
+            await ctx.send(
+                embed=Embed()
+                .set_thumbnail(url=image_url)
+                .add_field(self.trans.format_lang(source), dsafe(text)[:1024])
+                .add_field(self.trans.format_lang(target), dsafe(trans_text)[:1024], inline=False)
+            )
+
+    async def handle_annotation(self, ctx: Context, image_url: str | None) -> str | None:
+        if not image_url and not (image_url := await ctx.rsearch("image_url")):
+            await ctx.send("No image or link provided")
+            return None
 
         try:
             text = await self.annotate(image_url)
         except OCRException:
-            async with self.session.get(image_url) as resp:
+            async with ctx.ara.session.get(image_url) as resp:
                 if not resp.ok:
                     logging.warning("OCR: Couldn't download image %s", image_url)
                     await ctx.reply("Couldn't read image")
-                    return
+                    return None
                 image_data = await resp.read()
             try:
                 text = await self.annotate(image_data)
             except OCRException:
                 logging.warning("OCR: Image failed %s", image_url)
                 await ctx.reply("Couldn't read image")
-                return
+                return None
 
         if not text:
-            await ctx.send("No text found")
-            return
+            await ctx.reply("No text found")
+            return None
 
-        await ctx.send(
-            embed=Embed(description=codeblock(text))
-            .set_thumbnail(url=image_url)
-            .set_footer(
-                text="Powered by Google Cloud Vision",
-                icon_url="http://vision-explorer.reactive.ai/images/Vision-API.png",
-            )
-            .with_author(ctx.author)
-        )
+        return text
 
     async def annotate(self, image: str | bytes) -> str | None:
-        data = await self.session.fetch_json(
+        data = await self.trans.gtrans.session.fetch_json(  # lol
             f"https://vision.googleapis.com/v1/images:annotate?key={self.g_ocr_key}",
             method="post",
             json={
@@ -76,6 +98,4 @@ class OpticalCharacterRecognition(Cog, category=Category.LOOKUP, keys={"g_ocr_ke
         response: dict[str, dict] = data["responses"][0]
         if error := response.get("error"):
             raise OCRException(image, error["code"], error["message"])
-        if "fullTextAnnotation" not in response:
-            return None
-        return response["fullTextAnnotation"]["text"]
+        return response["fullTextAnnotation"]["text"] if "fullTextAnnotation" in response else None

--- a/arabot/cogs/google/translate/client.py
+++ b/arabot/cogs/google/translate/client.py
@@ -11,9 +11,9 @@ LangCodeAndOrName = list[str]
 class TranslationClient:
     BASE_URL = "https://translation.googleapis.com/language/translate/v2"
 
-    def __init__(self, key: str, session: ClientSession | None = None):
+    def __init__(self, key: str, session: ClientSession):
         self.key = key
-        self.session = session or ClientSession()
+        self.session = session
         self._invalidate_language_cache.start()
 
     async def _api(self, method: str, **params: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
Added `;ocrtranslate` command that combines `;ocr` and `;translate`.
Command inherits parameters from `;translate`, as follows:
- `;ocrtranslate text` where `lang_from` is auto and `lang_to` is English
- `;ocrtranslate lang_to text` where `lang_from` is auto
- `;ocrtranslate lang_from lang_to text`
In all cases `text` can contain spaces.

In the current implementation `lang_from` is only passed to the translator and thus doesn't affect OCR language detection.
Output is similar to `;translate` but with a thumbnail.

 I've never combined commands before, so happy bug hunting!