### PR TITLE
Database integration

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -24,6 +24,7 @@ pylint:
 
 pycodestyle:
   disable:
+    - E402 # module level import not at top of file
     - E731 # do not assign a lambda expression, use a def
 
 pyflakes:

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 worker: python -OO -m arabot
+release: prisma db push

--- a/arabot/__init__.py
+++ b/arabot/__init__.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv as _load_dotenv
 
 from .core import Ara
 
-__version__ = "7.7.9"
+__version__ = "8.0.0-alpha1"
 
 _load_dotenv()
 TESTING = bool(_getenv("testing"))

--- a/arabot/__init__.py
+++ b/arabot/__init__.py
@@ -4,7 +4,7 @@ from subprocess import run as _run
 
 from dotenv import load_dotenv as _load_dotenv
 
-__version__ = "8.0.0-beta2"
+__version__ = "8.0.0-beta3"
 
 _load_dotenv()
 TESTING = bool(_getenv("testing"))

--- a/arabot/__init__.py
+++ b/arabot/__init__.py
@@ -4,7 +4,7 @@ from subprocess import run as _run
 
 from dotenv import load_dotenv as _load_dotenv
 
-__version__ = "8.0.0-alpha3"
+__version__ = "8.0.0-beta1"
 
 _load_dotenv()
 TESTING = bool(_getenv("testing"))

--- a/arabot/__init__.py
+++ b/arabot/__init__.py
@@ -4,7 +4,7 @@ from subprocess import run as _run
 
 from dotenv import load_dotenv as _load_dotenv
 
-__version__ = "8.0.0-beta3"
+__version__ = "8.0.0-rc1"
 
 _load_dotenv()
 TESTING = bool(_getenv("testing"))

--- a/arabot/__init__.py
+++ b/arabot/__init__.py
@@ -1,10 +1,12 @@
 from os import getenv as _getenv
+from subprocess import run as _run
 
 from dotenv import load_dotenv as _load_dotenv
 
+_run(("prisma", "db", "push"), check=True)  # Migrate MongoDB
 from .core import Ara
 
-__version__ = "8.0.0-alpha1"
+__version__ = "8.0.0-alpha2"
 
 _load_dotenv()
 TESTING = bool(_getenv("testing"))

--- a/arabot/__init__.py
+++ b/arabot/__init__.py
@@ -4,7 +4,7 @@ from subprocess import run as _run
 
 from dotenv import load_dotenv as _load_dotenv
 
-__version__ = "8.0.0-beta1"
+__version__ = "8.0.0-beta2"
 
 _load_dotenv()
 TESTING = bool(_getenv("testing"))

--- a/arabot/__init__.py
+++ b/arabot/__init__.py
@@ -1,12 +1,15 @@
+# pylint: disable=wrong-import-position
 from os import getenv as _getenv
 from subprocess import run as _run
 
 from dotenv import load_dotenv as _load_dotenv
 
-_run(("prisma", "db", "push"), check=True)  # Migrate MongoDB
-from .core import Ara
-
-__version__ = "8.0.0-alpha2"
+__version__ = "8.0.0-alpha3"
 
 _load_dotenv()
 TESTING = bool(_getenv("testing"))
+
+if not _getenv("HEROKU_APP_ID"):
+    _run(("prisma", "db", "push"), check=True)
+
+from .core import Ara

--- a/arabot/__main__.py
+++ b/arabot/__main__.py
@@ -18,9 +18,9 @@ def setup_logging() -> None:
 
 
 async def prefix_manager(ara: Ara, msg: disnake.Message) -> str | None:
-    pfx_pattern = r"a; *" if TESTING else rf"; *|ara +|<@!?{ara.user.id}> *"
-    if found := re.match(pfx_pattern, msg.content, re.IGNORECASE):
-        return found[0]
+    custom_prefix = await ara.db.get_guild_prefix(msg.guild.id) or ";"
+    pfx_pattern = rf"{re.escape(custom_prefix)}\s*|ara\s+|<@!?{ara.user.id}>\s*"
+    return found[0] if (found := re.match(pfx_pattern, msg.content, re.IGNORECASE)) else None
 
 
 def create_ara(*args, **kwargs) -> Ara:

--- a/arabot/core/__init__.py
+++ b/arabot/core/__init__.py
@@ -1,4 +1,5 @@
 from .bot import Ara
+from .database import AraDB
 from .enums import *
 from .errors import *
 from .patches import *

--- a/arabot/core/bot.py
+++ b/arabot/core/bot.py
@@ -12,9 +12,9 @@ import aiohttp
 import disnake
 from disnake.ext import commands
 from disnake.utils import format_dt, oauth_url, utcnow
-from prisma import Prisma
 
 from ..utils import mono, system_info
+from .database import AraDB
 from .errors import StopCommand
 from .patches import Context
 
@@ -44,6 +44,8 @@ def search_directory(path) -> Generator[str, None, None]:
 
 
 class Ara(commands.Bot):
+    db: AraDB
+
     def __init__(self, *args, **kwargs):
         self._cogs_path: str = kwargs.pop("cogs_path", "arabot/modules")
         embed_color: int | disnake.Color | None = kwargs.pop("embed_color", None)
@@ -93,7 +95,7 @@ class Ara(commands.Bot):
     async def start(self) -> None:
         async with (
             aiohttp.ClientSession() as self.session,
-            Prisma() as self.db,
+            AraDB() as self.db,
         ):
             await self.login()
             self.load_extensions()

--- a/arabot/core/database.py
+++ b/arabot/core/database.py
@@ -1,0 +1,18 @@
+from async_lru import alru_cache
+from prisma import Prisma
+
+
+class AraDB(Prisma):
+    @alru_cache(cache_exceptions=False)
+    async def get_guild_prefix(self, guild_id: int) -> str | None:
+        return getattr(await self.prefix.find_unique({"guild_id": str(guild_id)}), "prefix", None)
+
+    async def set_guild_prefix(self, guild_id: int, prefix: str) -> None:
+        identifier = {"guild_id": str(guild_id)}
+        await self.prefix.upsert(
+            identifier,
+            {
+                "create": {"prefix": prefix} | identifier,
+                "update": {"prefix": prefix},
+            },
+        )

--- a/arabot/core/enums.py
+++ b/arabot/core/enums.py
@@ -37,6 +37,7 @@ class Category(str, Enum):
     MODERATION = "Moderation"
     GAMES = "Games"
     WAIFUS = "Reaction pictures"
+    SETTINGS = "Settings"
 
     def __str__(self) -> str:
         return self.value

--- a/arabot/modules/eval/__init__.py
+++ b/arabot/modules/eval/__init__.py
@@ -40,6 +40,7 @@ class Eval(Cog, category=Category.GENERAL):
                 channel=ctx.channel,
                 bot=ctx.bot,
                 ara=ctx.bot,
+                db=ctx.ara.db,
                 disnake=disnake,
                 discord=disnake,
                 commands=commands,

--- a/arabot/modules/settings.py
+++ b/arabot/modules/settings.py
@@ -1,27 +1,34 @@
 import disnake
 from arabot.core import Ara, AraDB, Category, Cog, Context
-from arabot.utils import mono
+from arabot.utils import bold, mono
 from disnake.ext import commands
 
 
 class Settings(Cog, category=Category.SETTINGS):
     @commands.group(aliases=["set"], invoke_without_command=True)
     async def settings(self, ctx: Context):
-        pass
+        await ctx.send(
+            embed=disnake.Embed().add_field(
+                "Available settings",
+                "\n".join(c.name for c in self.settings.walk_commands()),
+            )
+        )
 
     @settings.command(brief="Show bot's prefix on this server")
     async def prefix(self, ctx: Context, prefix: str | None = None):
         db: AraDB = ctx.ara.db
-        embed = disnake.Embed(title="Prefix").set_author(name=ctx.guild, icon_url=ctx.guild.icon)
+        embed = disnake.Embed(
+            description="_Additionally you can use **`ara`** or mention me_"
+        ).set_author(name=ctx.guild, icon_url=ctx.guild.icon)
 
         if prefix:
+            prefix = prefix.strip()
             await db.set_guild_prefix(ctx.guild.id, prefix)
             db.get_guild_prefix.invalidate(db, ctx.guild.id)
-            embed.description = mono(prefix)
         else:
-            prefix = await db.get_guild_prefix(ctx.guild.id)
-            embed.description = mono(prefix or ";")
+            prefix = await db.get_guild_prefix(ctx.guild.id) or ";"
 
+        embed.title = f"Prefix: {bold(mono(prefix))}"
         await ctx.send(embed=embed)
 
 

--- a/arabot/modules/settings.py
+++ b/arabot/modules/settings.py
@@ -5,7 +5,7 @@ from disnake.ext import commands
 
 
 class Settings(Cog, category=Category.SETTINGS):
-    @commands.group(aliases=["set"], invoke_without_command=True)
+    @commands.group(aliases=["set"], brief="Various bot settings", invoke_without_command=True)
     async def settings(self, ctx: Context):
         await ctx.send(
             embed=disnake.Embed().add_field(
@@ -14,7 +14,8 @@ class Settings(Cog, category=Category.SETTINGS):
             )
         )
 
-    @settings.command(brief="Show bot's prefix on this server")
+    @commands.has_permissions(manage_guild=True)
+    @settings.command(brief="View or set bot's prefix for this server")
     async def prefix(self, ctx: Context, prefix: str | None = None):
         db: AraDB = ctx.ara.db
         embed = disnake.Embed(

--- a/arabot/modules/settings.py
+++ b/arabot/modules/settings.py
@@ -1,0 +1,29 @@
+import disnake
+from arabot.core import Ara, AraDB, Category, Cog, Context
+from arabot.utils import mono
+from disnake.ext import commands
+
+
+class Settings(Cog, category=Category.SETTINGS):
+    @commands.group(aliases=["set"], invoke_without_command=True)
+    async def settings(self, ctx: Context):
+        pass
+
+    @settings.command(brief="Show bot's prefix on this server")
+    async def prefix(self, ctx: Context, prefix: str | None = None):
+        db: AraDB = ctx.ara.db
+        embed = disnake.Embed(title="Prefix").set_author(name=ctx.guild, icon_url=ctx.guild.icon)
+
+        if prefix:
+            await db.set_guild_prefix(ctx.guild.id, prefix)
+            db.get_guild_prefix.invalidate(db, ctx.guild.id)
+            embed.description = mono(prefix)
+        else:
+            prefix = await db.get_guild_prefix(ctx.guild.id)
+            embed.description = mono(prefix or ";")
+
+        await ctx.send(embed=embed)
+
+
+def setup(ara: Ara):
+    ara.add_cog(Settings())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 disnake[voice]~=2.5.0
+prisma
 # Speedups
 aiodns
 Brotli

--- a/schema.prisma
+++ b/schema.prisma
@@ -1,0 +1,9 @@
+datasource db {
+  provider = "mongodb"
+  url      = env("database_uri")
+}
+
+generator client {
+  provider             = "prisma-client-py"
+  recursive_type_depth = -1
+}

--- a/schema.prisma
+++ b/schema.prisma
@@ -7,3 +7,8 @@ generator client {
   provider             = "prisma-client-py"
   recursive_type_depth = -1
 }
+
+model Prefix {
+  guild_id String @id @map("_id")
+  prefix   String
+}


### PR DESCRIPTION
Set up MongoDB running on [MongoDB Atlas cluster](https://cloud.mongodb.com).
Programmatically accessed via the [Prisma ORM](https://prisma-client-py.readthedocs.io), whose schema is defined in `schema.prisma`.

Currently only one feature that utilizes the database has been implemented - custom guild prefixes.