### PR TITLE
Webhook rework

### DIFF
--- a/arabot/core/bot.py
+++ b/arabot/core/bot.py
@@ -155,17 +155,12 @@ class Ara(commands.Bot):
             else:
                 logging.info("Loaded %s", short)
 
-    async def fetch_webhook(self, name: str, msg: disnake.Message) -> disnake.Webhook | None:
-        reason = (
-            "Used for some functionality. It is safe to delete. Bot will recreate it when required."
-        )
-
-        channel = msg.channel.parent if isinstance(msg.channel, disnake.Thread) else msg.channel
-        webhooks = await channel.webhooks()
+    async def fetch_webhook(self, name: str, msg: disnake.Message) -> disnake.Webhook:
+        webhooks = await msg.channel.webhooks()
 
         return disnake.utils.get(
-            webhooks, user__id=self.user.id, name=name
-        ) or await channel.create_webhook(name=name, avatar=self.user.display_avatar, reason=reason)
+            webhooks, user=self.user, name=name
+        ) or await msg.channel.create_webhook(name=name, avatar=self.user.display_avatar)
 
     @override
     async def on_command_error(self, context: Context, exception: disnake.DiscordException) -> None:

--- a/arabot/core/bot.py
+++ b/arabot/core/bot.py
@@ -155,6 +155,20 @@ class Ara(commands.Bot):
             else:
                 logging.info("Loaded %s", short)
 
+    @staticmethod
+    async def get_webhook(name: str, ctx: Context) -> disnake.Webhook | None:
+        reason = (
+            "Used for some functionality. It is safe to delete. Bot will recreate it when required."
+        )
+
+        user = ctx.bot.user
+        channel = ctx.channel.parent if isinstance(ctx.channel, disnake.Thread) else ctx.channel
+        webhooks = await channel.webhooks()
+
+        return disnake.utils.get(
+            webhooks, user__id=user.id, name=name
+        ) or await channel.create_webhook(name=name, avatar=user.display_avatar, reason=reason)
+
     @override
     async def on_command_error(self, context: Context, exception: disnake.DiscordException) -> None:
         match exception:

--- a/arabot/core/bot.py
+++ b/arabot/core/bot.py
@@ -155,19 +155,17 @@ class Ara(commands.Bot):
             else:
                 logging.info("Loaded %s", short)
 
-    @staticmethod
-    async def get_webhook(name: str, ctx: Context) -> disnake.Webhook | None:
+    async def get_webhook(self, name: str, msg: disnake.Message) -> disnake.Webhook | None:
         reason = (
             "Used for some functionality. It is safe to delete. Bot will recreate it when required."
         )
 
-        user = ctx.bot.user
-        channel = ctx.channel.parent if isinstance(ctx.channel, disnake.Thread) else ctx.channel
+        channel = msg.channel.parent if isinstance(msg.channel, disnake.Thread) else msg.channel
         webhooks = await channel.webhooks()
 
         return disnake.utils.get(
-            webhooks, user__id=user.id, name=name
-        ) or await channel.create_webhook(name=name, avatar=user.display_avatar, reason=reason)
+            webhooks, user__id=self.user.id, name=name
+        ) or await channel.create_webhook(name=name, avatar=self.user.display_avatar, reason=reason)
 
     @override
     async def on_command_error(self, context: Context, exception: disnake.DiscordException) -> None:

--- a/arabot/core/bot.py
+++ b/arabot/core/bot.py
@@ -155,7 +155,7 @@ class Ara(commands.Bot):
             else:
                 logging.info("Loaded %s", short)
 
-    async def get_webhook(self, name: str, msg: disnake.Message) -> disnake.Webhook | None:
+    async def fetch_webhook(self, name: str, msg: disnake.Message) -> disnake.Webhook | None:
         reason = (
             "Used for some functionality. It is safe to delete. Bot will recreate it when required."
         )

--- a/arabot/core/patches.py
+++ b/arabot/core/patches.py
@@ -313,6 +313,7 @@ disnake.Message.temp_channel_mute_author = property(
 disnake.Message.blue_tick = message_blue_tick
 disnake.Message.tick = message_green_tick
 disnake.Thread.create_webhook = property(lambda self: self.parent.create_webhook)
+disnake.Thread.webhooks = property(lambda self: self.parent.webhooks)
 disnake.VoiceChannel.connect_play_disconnect = connect_play_disconnect
 
 

--- a/arabot/modules/chat.py
+++ b/arabot/modules/chat.py
@@ -113,7 +113,7 @@ class Chat(Cog):
 
         await msg.delete()
         someone = random.choice(msg.channel.members)
-        sender = await self.ara.get_webhook("somebody", msg)
+        sender = await self.ara.fetch_webhook("somebody", msg)
         await sender.send(
             AT_SOMEONE.sub(someone.mention, msg.content),
             username=msg.author.display_name,

--- a/arabot/modules/chat.py
+++ b/arabot/modules/chat.py
@@ -113,13 +113,13 @@ class Chat(Cog):
 
         await msg.delete()
         someone = random.choice(msg.channel.members)
-        sender = await msg.channel.create_webhook(name=msg.author, avatar=msg.author.display_avatar)
+        sender = await self.ara.get_webhook("somebody", msg)
         await sender.send(
             AT_SOMEONE.sub(someone.mention, msg.content),
             username=msg.author.display_name,
+            avatar_url=msg.author.display_avatar,
             allowed_mentions=disnake.AllowedMentions(users=True),
         )
-        await sender.delete()
 
     @pfxless(regex="^ok$", allow_bots=True)
     async def ok(self, msg: disnake.Message):

--- a/arabot/modules/general.py
+++ b/arabot/modules/general.py
@@ -257,6 +257,7 @@ class General(Cog, category=Category.GENERAL):
 
         await ctx.message.delete()
         webhook = await self.ara.fetch_webhook("impersonate", ctx.message)
+
         send = partial(
             webhook.send,
             flags=disnake.MessageFlags(

--- a/arabot/modules/general.py
+++ b/arabot/modules/general.py
@@ -5,6 +5,7 @@ from types import NoneType
 
 import disnake
 from disnake.ext import commands
+from disnake.utils import MISSING
 
 from arabot.core import Ara, Category, Cog, Context
 from arabot.utils import (CUSTOM_EMOJI_RE, AnyEmoji, AnyEmojis, AnyMember,
@@ -248,12 +249,13 @@ class General(Cog, category=Category.GENERAL):
             return
 
         await ctx.message.delete()
-        webhook = await self.ara.get_webhook("impersonate", ctx)
+        webhook = await self.ara.get_webhook("impersonate", ctx.message)
         send = partial(
             webhook.send,
             flags=disnake.MessageFlags(
                 suppress_notifications=ctx.message.flags.suppress_notifications
             ),
+            thread=ctx.channel if isinstance(ctx.channel, disnake.Thread) else MISSING,
         )
         await send(
             text,

--- a/arabot/modules/general.py
+++ b/arabot/modules/general.py
@@ -8,8 +8,15 @@ from disnake.ext import commands
 from disnake.utils import MISSING
 
 from arabot.core import Ara, Category, Cog, Context
-from arabot.utils import (CUSTOM_EMOJI_RE, AnyEmoji, AnyEmojis, AnyMember,
-                          AnyMemberOrUser, Twemoji, bold)
+from arabot.utils import (
+    CUSTOM_EMOJI_RE,
+    AnyEmoji,
+    AnyEmojis,
+    AnyMember,
+    AnyMemberOrUser,
+    Twemoji,
+    bold,
+)
 
 HTTP_CATS_VALID_CODES = {
     100, 101, 102,
@@ -249,7 +256,7 @@ class General(Cog, category=Category.GENERAL):
             return
 
         await ctx.message.delete()
-        webhook = await self.ara.get_webhook("impersonate", ctx.message)
+        webhook = await self.ara.fetch_webhook("impersonate", ctx.message)
         send = partial(
             webhook.send,
             flags=disnake.MessageFlags(

--- a/arabot/modules/general.py
+++ b/arabot/modules/general.py
@@ -5,18 +5,10 @@ from types import NoneType
 
 import disnake
 from disnake.ext import commands
-from disnake.utils import MISSING
 
 from arabot.core import Ara, Category, Cog, Context
-from arabot.utils import (
-    CUSTOM_EMOJI_RE,
-    AnyEmoji,
-    AnyEmojis,
-    AnyMember,
-    AnyMemberOrUser,
-    Twemoji,
-    bold,
-)
+from arabot.utils import (CUSTOM_EMOJI_RE, AnyEmoji, AnyEmojis, AnyMember,
+                          AnyMemberOrUser, Twemoji, bold)
 
 HTTP_CATS_VALID_CODES = {
     100, 101, 102,
@@ -256,13 +248,12 @@ class General(Cog, category=Category.GENERAL):
             return
 
         await ctx.message.delete()
-        webhook = await ctx.channel.create_webhook(name=user)
+        webhook = await self.ara.get_webhook("impersonate", ctx)
         send = partial(
             webhook.send,
             flags=disnake.MessageFlags(
                 suppress_notifications=ctx.message.flags.suppress_notifications
             ),
-            thread=ctx.channel if isinstance(ctx.channel, disnake.Thread) else MISSING,
         )
         await send(
             text,
@@ -270,7 +261,6 @@ class General(Cog, category=Category.GENERAL):
             username=WEBHOOK_RESERVED_NAMES.get(user.display_name, user.display_name),
             allowed_mentions=disnake.AllowedMentions(users=True),
         )
-        await webhook.delete()
 
 
 def setup(ara: Ara):


### PR DESCRIPTION
I implemented KrizBOT into AraBOT.
It is slightly improved version where we provide message instead of context and read bot avatar from self.

There is one thing that need to be added but I'm not sure how to do it in elegant way.
You will get error when bot attempts to create new webhook but there is no more space for it in channel

Discord limit per channel is 15 webhooks so it is rare but can happen